### PR TITLE
Fix gem dependencies; version bump

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in kantox-chronoscope.gemspec
 gemspec
-gem "codeclimate-test-reporter", group: :test, require: nil

--- a/kantox-chronoscope.gemspec
+++ b/kantox-chronoscope.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'pry', '~> 0.10'
   spec.add_development_dependency 'awesome_print', '~> 1'
-  spec.add_development_dependency 'codeclimate-test-reporter'
+  spec.add_development_dependency 'simplecov'
 
   spec.add_dependency 'kungfuig', '~> 0.7'
 end

--- a/kantox-chronoscope.gemspec
+++ b/kantox-chronoscope.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'pry', '~> 0.10'
   spec.add_development_dependency 'awesome_print', '~> 1'
+  spec.add_development_dependency 'codeclimate-test-reporter'
 
   spec.add_dependency 'kungfuig', '~> 0.7'
 end

--- a/lib/kantox/chronoscope/generic.rb
+++ b/lib/kantox/chronoscope/generic.rb
@@ -133,9 +133,9 @@ module Kantox
       end
 
       def log_width
-        # rubocop:disable Style/RescueModifier
-        $stdin.winsize.last - 10 rescue 80
-        # rubocop:enable Style/RescueModifier
+        ($stdin.winsize.last.nonzero? || 90) - 10
+      rescue
+        80
       end
 
       protected :log_problem, :log_bm, :log_report, :log_width

--- a/lib/kantox/chronoscope/version.rb
+++ b/lib/kantox/chronoscope/version.rb
@@ -1,5 +1,5 @@
 module Kantox
   module Chronoscope
-    VERSION = '0.7.3'
+    VERSION = '0.7.4'
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'pry'
+require 'simplecov'
+SimpleCov.start
+
 require 'kantox/chronoscope'
 
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start


### PR DESCRIPTION
CodeClimate has a ruby-test-reporter but it does not work inside the test suite anymore. It just uploads the results of SimpleCov.

This change swaps out ruby-test-reporter for simplecov, and adds it into the normal gem dev dependencies.